### PR TITLE
feat: allow for hybrid Metal-CPU execution

### DIFF
--- a/lib/nx_iree/compiler.ex
+++ b/lib/nx_iree/compiler.ex
@@ -154,6 +154,8 @@ defmodule NxIREE.Compiler do
           filtered_inputs =
             filter_inputs_by_indices(inputs, used_inputs)
 
+          dbg({mlir_module, iree_compiler_flags, filtered_inputs})
+
           {:ok, result} =
             NxIREE.call(
               nx_iree_module,

--- a/lib/nx_iree/compiler.ex
+++ b/lib/nx_iree/compiler.ex
@@ -18,7 +18,7 @@ defmodule NxIREE.Compiler do
 
   @impl true
   def __compile__(_key, vars, fun, opts) do
-    {iree_compiler_flags, opts} = Keyword.pop(opts, :iree_compiler_flags, nil)
+    {iree_compiler_flags, opts} = Keyword.pop(opts, :iree_compiler_flags, [])
     {iree_runtime_options, opts} = Keyword.pop(opts, :iree_runtime_options, [])
     {output_mode, opts} = Keyword.pop(opts, :output_mode, nil)
 

--- a/lib/nx_iree/compiler/graph_splitter.ex
+++ b/lib/nx_iree/compiler/graph_splitter.ex
@@ -228,7 +228,7 @@ defmodule NxIREE.Compiler.GraphSplitter do
   end
 
   defp rewrite_subtree(
-         %T{data: %Expr{op: :optional, id: id, args: [call, subexpr, fun]}} = expr,
+         %T{data: %Expr{op: :optional, id: id, args: [_call, subexpr, _fun]}},
          state,
          acc
        ) do
@@ -237,9 +237,9 @@ defmodule NxIREE.Compiler.GraphSplitter do
         {res, put_in(acc.used_args[id], {res, state.shards[id]})}
 
       _ ->
-        {call, acc} = rewrite_subtree(call, state, acc)
-        expr = put_in(expr.data.args, [call, subexpr, fun])
-        {expr, acc}
+        # TO-DO: allow for the optional node to go through the pipeline
+        # We're instead always relying on the default implementation here.
+        rewrite_subtree(subexpr, state, acc)
     end
   end
 

--- a/lib/nx_iree/compiler/graph_splitter.ex
+++ b/lib/nx_iree/compiler/graph_splitter.ex
@@ -8,7 +8,6 @@ defmodule NxIREE.Compiler.GraphSplitter do
     :count_leading_zeros,
     :population_count,
     :sort,
-    :all_close,
     :mode,
     :argmax,
     :argmin,
@@ -52,10 +51,6 @@ defmodule NxIREE.Compiler.GraphSplitter do
               expr,
               %{state | nodes_to_replace: nodes_to_replace}
             )
-
-          # dbg(expr, structs: false)
-          # dbg(used_args)
-          # raise "asdf"
 
           arg_remapping =
             used_args

--- a/lib/nx_iree/compiler/graph_splitter.ex
+++ b/lib/nx_iree/compiler/graph_splitter.ex
@@ -1,0 +1,232 @@
+defmodule NxIREE.Compiler.GraphSplitter do
+  alias Nx.Defn.Composite
+
+  alias Nx.Tensor, as: T
+  alias Nx.Defn.Expr
+
+  @non_metal_ops [:fft, :sort]
+
+  def traverse(expr, expr_shards \\ %{}) do
+    # expression_chain is going to be a reverse-accumulation of {category, subexpr}
+    # that we can then compile and chain-execute elsewhere. category is either :gather, :reduce or :none
+    state = %{
+      expression_chain: [],
+      nodes_to_replace: %{},
+      # contains the sharding configuration for each node by id
+      shards: expr_shards,
+      # args is a map of id -> {stage_id, output_container_position}
+      args: %{}
+    }
+
+    cache = %{}
+    {expr, {cache, state}} = composite_eval(expr, state, cache)
+
+    expr_chain =
+      Enum.reduce(
+        [{make_ref(), :none, expr, state.nodes_to_replace} | state.expression_chain],
+        [],
+        fn {id, category, expr, nodes_to_replace}, acc ->
+          # TO-DO: we need to also do a pass to avoid recalculating results that have been previously calculated.
+          # For example:
+          # x = arg0 + arg1
+          # y = arg0 - arg1
+          # z = x + y
+          # -----
+          # w = dot(z, arg1)
+          # y + w <- here, we currently have to recalculate y given that only z, arg0 and arg1 will be passed as arguments.
+          #          ideally, we should also pass y as a value to avoid recalculating it.
+          #          We might be able to calculate this in the first traversal somehow.
+
+          {expr, %{used_args: used_args}} =
+            composite_rewrite_subtree(
+              expr,
+              %{state | nodes_to_replace: nodes_to_replace}
+            )
+
+          arg_remapping =
+            used_args
+            |> Enum.sort_by(fn {_id, {%T{data: %Expr{op: :parameter, args: [idx]}}, _shards}} ->
+              idx
+            end)
+            |> Enum.with_index(fn
+              {id, {expr, nil}}, idx ->
+                {id, put_in(expr.data.args, [idx])}
+
+              {id, {expr, shard_propagation}}, idx ->
+                expr = put_in(expr.data.args, [idx])
+                expr = Expr.metadata(expr, %{shards: shard_propagation.shards})
+                {id, expr}
+            end)
+            |> Map.new()
+
+          {expr, _} =
+            composite_rewrite_subtree(expr, %{state | nodes_to_replace: arg_remapping})
+
+          expr =
+            Composite.traverse(expr, fn
+              %T{data: %Expr{id: id}} = t ->
+                if shard_propagation = state.shards[id] do
+                  Expr.metadata(t, %{shards: shard_propagation.shards})
+                else
+                  t
+                end
+
+              other ->
+                other
+            end)
+
+          arguments = Map.new(arg_remapping, fn {_id, expr} -> {expr.data.id, expr} end)
+
+          argument_sources =
+            Map.take(state.args, Map.keys(arg_remapping))
+            |> Map.new(fn {remap_id, v} ->
+              {arg_remapping[remap_id].data.id, v}
+            end)
+
+          [{id, category, expr, arguments, argument_sources} | acc]
+        end
+      )
+
+    {expr_chain, Map.delete(state, :expression_chain), cache}
+  end
+
+  defp composite_eval(expr, state, cache) do
+    Composite.traverse(expr, {cache, state}, &eval/2)
+  end
+
+  defp eval(%T{data: %Expr{id: id, op: op}} = ans, {cache, state}) do
+    case {cache, state.nodes_to_replace} do
+      {_, %{^id => res}} ->
+        # Replace the node with the corresponding parameter
+        {res, {Map.put(cache, id, res), state}}
+
+      {%{^id => res}, _} ->
+        {res, {cache, state}}
+
+      {_, _} ->
+        cond do
+          op in @non_metal_ops ->
+            rewrite_args(ans, {cache, state})
+
+          true ->
+            eval_apply(op, ans, {cache, state})
+        end
+    end
+  end
+
+  defp eval(other, {cache, state}) do
+    {other, {cache, state}}
+  end
+
+  defp rewrite_args(expr, {cache, state}) do
+    {args, {cache, state}} = Nx.Defn.Tree.apply_args(expr, {cache, state}, &eval/2)
+
+    # We need to save this so that each previous stage
+    # isn't affected by following ones
+    nodes_to_replace = state.nodes_to_replace
+
+    stage_id = make_ref()
+    second_stage_id = make_ref()
+
+    {args, {tensor_args, _out_position, state}} =
+      Enum.map_reduce(args, {[], 0, state}, fn
+        %T{} = expr, {tensor_args, out_position, state} ->
+          arg = Expr.parameter(expr, map_size(state.args))
+
+          state = %{
+            state
+            | args: Map.put(state.args, arg.data.id, {stage_id, out_position}),
+              nodes_to_replace: Map.put(state.nodes_to_replace, expr.data.id, arg),
+              shards: Map.put(state.shards, arg.data.id, state.shards[expr.data.id])
+          }
+
+          {arg, {[expr | tensor_args], out_position + 1, state}}
+
+        non_tensor_arg, acc ->
+          {non_tensor_arg, acc}
+      end)
+
+    new_expr = put_in(expr.data.args, args)
+
+    arg = Expr.parameter(new_expr, map_size(state.args))
+
+    state = %{
+      state
+      | args: Map.put(state.args, arg.data.id, {second_stage_id, 0}),
+        nodes_to_replace: Map.put(state.nodes_to_replace, new_expr.data.id, arg)
+    }
+
+    state =
+      update_in(
+        state.expression_chain,
+        &[
+          {second_stage_id, :force_host, {new_expr}, nodes_to_replace},
+          {stage_id, :none, List.to_tuple(Enum.reverse(tensor_args)), nodes_to_replace}
+          | &1
+        ]
+      )
+
+    cache = Map.put(cache, new_expr.data.id, new_expr)
+    cache = Map.put(cache, arg.data.id, arg)
+
+    {arg, {cache, state}}
+  end
+
+  defp eval_apply(:parameter, %T{data: %Expr{id: id, args: [idx]}} = expr, {cache, state}) do
+    state = put_in(state.args[id], {nil, idx})
+    {expr, {Map.put(cache, id, expr), state}}
+  end
+
+  defp eval_apply(:elem, %T{data: %Expr{id: id, args: [tuple, i]}}, {cache, state}) do
+    {tuple, cache} = composite_eval(tuple, state, cache)
+    res = elem(tuple, i)
+    {res, {Map.put(cache, id, res), state}}
+  end
+
+  defp eval_apply(_op, %T{data: %Expr{id: id}} = ans, {cache, state}) do
+    {args, {cache, state}} = Nx.Defn.Tree.apply_args(ans, {cache, state}, &eval/2)
+    ans = put_in(ans.data.args, args)
+    {ans, {Map.put(cache, id, ans), state}}
+  end
+
+  defp composite_rewrite_subtree(args, state, acc \\ %{used_args: %{}})
+
+  defp composite_rewrite_subtree(args, state, acc) when is_list(args) do
+    Enum.map_reduce(args, acc, fn
+      %T{} = arg, acc ->
+        composite_rewrite_subtree(arg, state, acc)
+
+      arg, acc ->
+        {arg, acc}
+    end)
+  end
+
+  defp composite_rewrite_subtree(%T{data: %Expr{id: id, op: :parameter}} = expr, state, acc) do
+    case state.nodes_to_replace do
+      %{^id => res} ->
+        {res, put_in(acc.used_args[id], {res, state.shards[id]})}
+
+      _ ->
+        {expr, put_in(acc.used_args[id], {expr, state.shards[id]})}
+    end
+  end
+
+  defp composite_rewrite_subtree(arg, state, acc) do
+    Composite.traverse(arg, acc, &rewrite_subtree(&1, state, &2))
+  end
+
+  defp rewrite_subtree(%T{data: %Expr{id: id, args: args}} = expr, state, acc) do
+    case state.nodes_to_replace do
+      %{^id => res} ->
+        # nodes_to_replace always contains a param
+        {res, put_in(acc.used_args[id], res)}
+
+      _ ->
+        {args, acc} = composite_rewrite_subtree(args, state, acc)
+
+        {put_in(expr.data.args, args), acc}
+    end
+  end
+
+  defp rewrite_subtree(other, _, acc), do: {other, acc}
+end

--- a/lib/nx_iree/compiler/graph_splitter.ex
+++ b/lib/nx_iree/compiler/graph_splitter.ex
@@ -210,6 +210,9 @@ defmodule NxIREE.Compiler.GraphSplitter do
       %T{} = arg, acc ->
         composite_rewrite_subtree(arg, state, acc)
 
+      arg, acc when is_list(arg) ->
+        composite_rewrite_subtree(arg, state, acc)
+
       arg, acc ->
         {arg, acc}
     end)

--- a/test/nx_iree/nx_test.exs
+++ b/test/nx_iree/nx_test.exs
@@ -62,28 +62,30 @@ defmodule NxIREE.NxTest do
     window_mean: 3,
     window_sum: 3,
     window_min: 3,
-    window_max: 3,
+    window_max: 3
   ]
 
-  if Nx.Defn.default_options()[:iree_runtime_options][:device].driver_name == "metal" do
-    @metal_only_errors [
-      count_leading_zeros: 1,
-      population_count: 1,
-      # incorrect implementation in IREE
-      sort: 2,
-      # fails on nan comparison
-      all_close: 3,
-      mode: 2,
-      argmax: 2,
-      argmin: 2,
-      is_nan: 1,
-      # C-level abort
-      median: 2
-    ]
-  else
-    @metal_only_errors []
-  end
+  # if Nx.Defn.default_options()[:iree_runtime_options][:device].driver_name == "metal" do
+  #   @metal_only_errors [
+  #     count_leading_zeros: 1,
+  #     population_count: 1,
+  #     # incorrect implementation in IREE
+  #     sort: 2,
+  #     # fails on nan comparison
+  #     all_close: 3,
+  #     mode: 2,
+  #     argmax: 2,
+  #     argmin: 2,
+  #     is_nan: 1,
+  #     # C-level abort
+  #     median: 2
+  #   ]
+  # else
+  @metal_only_errors []
+  # end
 
   doctest Nx,
-    except: @illegal_ops ++ @rounding_error ++ @partial_support ++ @errors_to_be_fixed ++ @metal_only_errors
+    except:
+      @illegal_ops ++
+        @rounding_error ++ @partial_support ++ @errors_to_be_fixed ++ @metal_only_errors
 end

--- a/test/nx_iree/nx_test.exs
+++ b/test/nx_iree/nx_test.exs
@@ -65,27 +65,8 @@ defmodule NxIREE.NxTest do
     window_max: 3
   ]
 
-  # if Nx.Defn.default_options()[:iree_runtime_options][:device].driver_name == "metal" do
-  #   @metal_only_errors [
-  #     count_leading_zeros: 1,
-  #     population_count: 1,
-  #     # incorrect implementation in IREE
-  #     sort: 2,
-  #     # fails on nan comparison
-  #     all_close: 3,
-  #     mode: 2,
-  #     argmax: 2,
-  #     argmin: 2,
-  #     is_nan: 1,
-  #     # C-level abort
-  #     median: 2
-  #   ]
-  # else
-  @metal_only_errors []
-  # end
-
   doctest Nx,
     except:
       @illegal_ops ++
-        @rounding_error ++ @partial_support ++ @errors_to_be_fixed ++ @metal_only_errors
+        @rounding_error ++ @partial_support ++ @errors_to_be_fixed
 end


### PR DESCRIPTION
Some functions in the Metal driver for IREE aren't working properly.
This PR uses a version of the Nx GraphSplitter to enable execution of said functions
on the CPU.

This is highly experimental. However, seeing as these functions don't work correctly
today already, we aren't at risk of a worse UX by always forcing this behavior.
